### PR TITLE
Python側のデバッグ作業とフロントにおけるUX向上作業

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,3 @@ pymongo==4.5.0
 fastapi==0.96.0
 uvicorn[standard]==0.22.0
 websockets==11.0.3
-starlette==0.27.0

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -5,7 +5,6 @@ import asyncio
 
 from fastapi import Depends, FastAPI, WebSocket
 from fastapi.responses import JSONResponse
-from fastapi.middleware.cors import CORSMiddleware
 
 import mongo
 from ws import clients, send_ws, root, ws_user, ws_pass
@@ -24,20 +23,6 @@ for i in item_types:
     tickets[i] = manager.new(i)
 
 app = FastAPI()
-
-origins = [
-    "http://192.168.0.3:3000",
-]
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    # 認証情報のアクセスを許可(今回は必要ない)
-    allow_credentials=True,
-    # 全てのリクエストメソッドを許可(["GET", "POST"]など個別指定も可能)
-    allow_methods=["*"],
-    # アクセス可能なレスポンスヘッダーを設定（今回は必要ない）
-    allow_headers=["*"],     
-)
 
 @app.get('%s/ready' % root)
 async def ready():

--- a/backend/src/mongo.py
+++ b/backend/src/mongo.py
@@ -68,22 +68,22 @@ class TicketManager:
         return data
         
     def to_ready_ticket(self, item_number):
-        if not self.tickets.find_one({'item_number': item_number}, {'status': 'wait'}):
+        if not self.tickets.find_one({'$and': [{'item_number': item_number}, {'status': 'wait'}]}):
             raise HTTPException(status_code=404, detail=f'Not Found: {item_number}')
         return self.tickets.update_one({'$and': [{'item_number': item_number}, {'status': 'wait'}]}, {'$set': {'status': 'ready'}})
     
     def to_wait_ticket(self, item_number):
-        if not self.tickets.find_one({'item_number': item_number}, {'status': 'ready'}):
+        if not self.tickets.find_one({'$and': [{'item_number': item_number}, {'status': 'ready'}]}):
             raise HTTPException(status_code=404, detail=f'Not Found: {item_number}')
         return self.tickets.update_one({'$and': [{'item_number': item_number}, {'status': 'ready'}]}, {'$set': {'status': 'wait'}})
 
     def cancel_ticket(self, item_number):
-        if not self.tickets.find_one({'item_number': item_number}, {'status': 'wait'}):
+        if not self.tickets.find_one({'$and': [{'item_number': item_number}, {'status': 'wait'}]}):
             raise HTTPException(status_code=404, detail=f'Not Found: {item_number}')
         return self.tickets.update_one({'$and': [{'item_number': item_number}, {'status': 'wait'}]}, {'$set': {'status': 'cancel'}})
     
     def delete_ticket(self, item_number):
-        if not self.tickets.find_one({'item_number': item_number}, {'status': 'ready'}):
+        if not self.tickets.find_one({'$and': [{'item_number': item_number}, {'status': 'ready'}]}):
             raise HTTPException(status_code=404, detail=f'Not Found: {item_number}')
         return self.tickets.update_one({'$and': [{'item_number': item_number}, {'status': 'ready'}]}, {'$set': {'status': 'delete'}})
 

--- a/backend/src/mongo.py
+++ b/backend/src/mongo.py
@@ -102,6 +102,8 @@ class TicketManager:
     def reset_tickets(self):
         if not self.tickets.delete_many({}):
             raise HTTPException(status_code=500, detail='Internal Server Error')
+        else:
+            self.last_ticket = 0
 
 class Manager(CollectionManager, TicketManager):
 

--- a/front/modeken-system/src/components/CreateModal.tsx
+++ b/front/modeken-system/src/components/CreateModal.tsx
@@ -13,7 +13,10 @@ import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import CloseIcon from '@mui/icons-material/Close';
-import { useForm, SubmitHandler } from "react-hook-form"
+import { useForm, SubmitHandler } from "react-hook-form";
+import { setTimeout } from 'timers';
+import MyBackdrop from './MyBackdrop';
+import MySnackBar from './MySnackbar';
 
 const steps_create = ['選択', '確認', '完了'];
 
@@ -45,14 +48,26 @@ const CreateModal: FC<MyComponentsProps>  = ({openCreate, handleCloseCreate}) =>
         handleCloseCreate(false)
         // stepをリセット
         setActiveStepCreate(0);
+        setAlert500(false)
+        setAlertAny(false)
     };
 
     // Select用
-    const [type, setType] = useState('');
+    const [type, setType] = useState<string>('');
 
     const handleChangeTypeSelect = (event: SelectChangeEvent) => {
         setType(event.target.value as string);
     };
+
+    // SnackBar用
+    const [CreateSnack, setCreateSnack] = useState<boolean>(false);
+
+    // Alert用
+    const [Alert500, setAlert500] = useState<boolean>(false);
+    const [AlertAny, setAlertAny] = useState<boolean>(false);
+
+    //Backdrop用
+    const [Backdrop, setBackdrop] = useState<boolean>(false);
 
     // Form用
     const { register, handleSubmit } = useForm<SelectType>()
@@ -60,6 +75,7 @@ const CreateModal: FC<MyComponentsProps>  = ({openCreate, handleCloseCreate}) =>
       handleNextCreate()
     }
     const onSubmitSecound: SubmitHandler<SelectType> = (data) => {
+      setBackdrop(true)
       //[APIで送信]
       const url = process.env.URI_BACK + 'api/v1.0/ticketing'
       const username = process.env.USERNAME
@@ -76,14 +92,34 @@ const CreateModal: FC<MyComponentsProps>  = ({openCreate, handleCloseCreate}) =>
             'itemType': data.item_type
           }),
       }
-      
-      fetch(url, Options).then((response) => {
-        console.log(response)
-      }).catch(err => console.log(err))
-      handleNextCreate()
+      const action = () => {
+        fetch(url, Options)
+        .then((response) => {
+          console.log(response)
+          try{
+            if (response.status == 200){
+              handleNextCreate()
+              setCreateSnack(true)
+            } else if (response.status == 500){
+              setAlert500(true)
+            } else {
+              setAlertAny(true)
+            }
+          } finally{
+            setBackdrop(false)
+            const showSnack = () => setCreateSnack(false)
+            setTimeout( showSnack, 2700)
+          }
+        })
+        .catch(err => {
+          console.log(err)
+        })
+      }
+      setTimeout(action,1000)
     }
     return (
         <>
+        {CreateSnack && <MySnackBar />}
         <Modal
             open={openCreate}
             onClose={handleCloseCreate}
@@ -170,6 +206,9 @@ const CreateModal: FC<MyComponentsProps>  = ({openCreate, handleCloseCreate}) =>
                       activeStepCreate === 1 ? (
                         <>
                           <Alert severity="info">発券を確定する前に内容が正しいか確認してください</Alert>
+                          { Alert500 &&  <Alert severity="error">発券することが出来ませんでした。再度発券しなおしてください。</Alert>}
+                          { AlertAny &&  <Alert severity="error">問題が発生しました。再度発券しなおしてください。</Alert>}
+                          { Backdrop && <MyBackdrop /> }
                           <form onSubmit={handleSubmit(onSubmitSecound)}>
                             <Typography id="modal-modal-title" variant="h6" component="h2" sx={{mt: 3,mb: 2}}>
                               種別

--- a/front/modeken-system/src/components/CreateModal.tsx
+++ b/front/modeken-system/src/components/CreateModal.tsx
@@ -108,18 +108,18 @@ const CreateModal: FC<MyComponentsProps>  = ({openCreate, handleCloseCreate}) =>
           } finally{
             setBackdrop(false)
             const showSnack = () => setCreateSnack(false)
-            setTimeout( showSnack, 2700)
+            setTimeout( showSnack, 3200)
           }
         })
         .catch(err => {
           console.log(err)
         })
       }
-      setTimeout(action,1000)
+      setTimeout(action,500)
     }
     return (
         <>
-        {CreateSnack && <MySnackBar />}
+        {CreateSnack && <MySnackBar setSeverity='success' AlertContent='発券が完了しました'/>}
         <Modal
             open={openCreate}
             onClose={handleCloseCreate}

--- a/front/modeken-system/src/components/MyBackdrop.tsx
+++ b/front/modeken-system/src/components/MyBackdrop.tsx
@@ -1,0 +1,20 @@
+import { useState, FC } from 'react';
+import Backdrop from '@mui/material/Backdrop';
+import CircularProgress from '@mui/material/CircularProgress';
+
+const SimpleBackdrop:FC = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div>
+      <Backdrop
+        sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
+        open={open}
+      >
+        <CircularProgress color="inherit" />
+      </Backdrop>
+    </div>
+  );
+}
+
+export default SimpleBackdrop;

--- a/front/modeken-system/src/components/MySnackbar.tsx
+++ b/front/modeken-system/src/components/MySnackbar.tsx
@@ -1,0 +1,27 @@
+import {useState, SyntheticEvent, Fragment} from 'react';
+import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+
+export default function SimpleSnackbar() {
+  const [open, setOpen] = useState(true);
+
+  const handleClose = (event: SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpen(false);
+  };
+
+  return (
+    <div>
+        <Snackbar open={open} autoHideDuration={2500} onClose={handleClose}>
+        <Alert onClose={handleClose} severity="success" sx={{ width: '100%' }}>
+            発券が完了しました
+        </Alert>
+        </Snackbar>
+    </div>
+  );
+}

--- a/front/modeken-system/src/components/MySnackbar.tsx
+++ b/front/modeken-system/src/components/MySnackbar.tsx
@@ -1,11 +1,16 @@
-import {useState, SyntheticEvent, Fragment} from 'react';
+import {useState, SyntheticEvent, FC} from 'react';
 import Button from '@mui/material/Button';
 import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
+import Alert, {AlertColor} from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 
-export default function SimpleSnackbar() {
+interface MyComponentsProps{
+  setSeverity: AlertColor | undefined,
+  AlertContent: string,
+}
+
+const SimpleSnackbar:FC<MyComponentsProps> = ({setSeverity, AlertContent}) => {
   const [open, setOpen] = useState(true);
 
   const handleClose = (event: SyntheticEvent | Event, reason?: string) => {
@@ -17,11 +22,13 @@ export default function SimpleSnackbar() {
 
   return (
     <div>
-        <Snackbar open={open} autoHideDuration={2500} onClose={handleClose}>
-        <Alert onClose={handleClose} severity="success" sx={{ width: '100%' }}>
-            発券が完了しました
+        <Snackbar open={open} autoHideDuration={3000} onClose={handleClose}>
+        <Alert onClose={handleClose} severity={setSeverity} sx={{ width: '100%' }}>
+            {AlertContent}
         </Alert>
         </Snackbar>
     </div>
   );
 }
+
+export default SimpleSnackbar;


### PR DESCRIPTION
# 変更点
## フロント
[Update]APIリクエストの成功時ににSnackBarが表示。エラーハンドリグを行いフロントで表示。発見時のローディングを実装(https://github.com/tochiman/modeken-ticket-system/commit/39a406a908704f16d72976fdd824e89cd9070600)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

[Update] スナックバーの表示時間が長くなったためそれに合わせて変更(https://github.com/tochiman/modeken-ticket-system/commit/9aaebca5a8490b26c119df3fc22b20ad5eb7d77f)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

[Update]好きなメッセージと色でスナックバーを表示させられるようになった(https://github.com/tochiman/modeken-ticket-system/commit/a375af8fb61e29d4d9ffe4419c271ab72cc1312e)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

## バックエンド
[Update]集計データの全削除ができるようになった(https://github.com/tochiman/modeken-ticket-system/commit/89b2a5e176068f502ceb82ee88853acc491c3af9)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

[Update]集計データを全削除された時にitemNumberが0にリセットされる(https://github.com/tochiman/modeken-ticket-system/commit/dade4896ad235b3a8072a59f81dbe7fee6164170)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

[Update]PythonのMiddlewareを挟まずにCORSの問題を解決できることが判明したため(https://github.com/tochiman/modeken-ticket-system/commit/8e4cbd5befd5f1a28fd1c6544b43f9a8905e4857)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

[Update]キャンセルが準備中でないと出来ないようにした。(https://github.com/tochiman/modeken-ticket-system/commit/d5522e70143737cf2604baf05b91c555825d3c17)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)

## その他
[Merge remote-tracking branch 'origin/main' into dev](https://github.com/tochiman/modeken-ticket-system/commit/84446f9f6b1ac8735f530ab3626f839ab3ebaa6c)
@[tochiman](https://github.com/tochiman/modeken-ticket-system/commits?author=tochiman)